### PR TITLE
Fix default less comparison to handle Inf cases correctly

### DIFF
--- a/llrb/llrb.go
+++ b/llrb/llrb.go
@@ -39,7 +39,13 @@ func less(x, y Item) bool {
 		return false
 	}
 	if x == ninf {
+		return y != ninf
+	}
+	if y == pinf {
 		return true
+	}
+	if y == ninf {
+		return false
 	}
 	return x.Less(y)
 }


### PR DESCRIPTION
The logic does not appear to handle the case where y is an instance of `Inf`. 

I was hitting this case in following the code, derived from an example in the LLRB code itself:

``` go
tree.AscendGreaterOrEqual(llrb.Inf(-1), func(item llrb.Item) bool { ... })
```
